### PR TITLE
정리 , 버그 #35 : menu.c 코드정리 , pellet 안먹어지는거 버그픽스 , 백스페이스 엔터 등 키 추가구현

### DIFF
--- a/pacman/src/main.c
+++ b/pacman/src/main.c
@@ -311,7 +311,6 @@ static void process_events(void)
 			break;
 		}
 	}
-
 	keyevents_finished();
 }
 
@@ -384,19 +383,20 @@ static void cp_pacman(PacmanGame* pac)
 	pacmanGame.pelletHolder.numLeft = pac->pelletHolder.numLeft;
 	pacmanGame.pelletHolder.totalNum = pac->pelletHolder.totalNum;
 	if(Multi_flags() == 1) // # 35 DOng : 버그 수정 펠렛먹으면 레벨 진행을 위함.
-	{
-		for(int i = 0 ; i <487; i++)
+	{//#35 Kim :  구석탱이 있는 펠렛 안먹어지는거 수정
+		for(int i = 0 ; i <488; i++)
 		{
 			cp_pellet(&pacmanGame.pelletHolder.pellets[i],&pac->pelletHolder.pellets[i]);
 		}
 	}
 	else
 	{
-		for(int i = 0 ; i <243; i++)
+		for(int i = 0 ; i <244; i++)
 		{
 			cp_pellet(&pacmanGame.pelletHolder.pellets[i],&pac->pelletHolder.pellets[i]);
 		}
 	}
+
 	pacmanGame.gameFruit1=pac->gameFruit1;
 	pacmanGame.gameFruit2=pac->gameFruit2;
 	pacmanGame.gameFruit3=pac->gameFruit3;
@@ -407,6 +407,5 @@ static void cp_pacman(PacmanGame* pac)
 	pacmanGame.gameObject3=pac->gameObject3;
 	pacmanGame.gameObject4=pac->gameObject4;
 	pacmanGame.gameObject5=pac->gameObject5;
-
 
 }

--- a/pacman/src/main.c
+++ b/pacman/src/main.c
@@ -184,6 +184,10 @@ static void internal_render(void)
 			pacmanGame.playMode= menuSystem.playMode;
 			state=Menu;
 			break;
+		case ReturnMenu://그냥 return menu에선 둘다 초기값으로 초기화
+			pacmanGame.playMode = menuSystem.playMode=Single;
+			state=Menu;
+			break;
 		default:
 			break;
 		}

--- a/pacman/src/menu.c
+++ b/pacman/src/menu.c
@@ -48,7 +48,9 @@ int menu_tick(MenuSystem *menuSystem)
 
 	if (startNew)
 	{
-		if(menuSystem->playMode==Online)
+		if (5000>(SDL_GetTicks() - menuSystem->ticksSinceModeChange))//#35 Kim : 이부분 설명 하자면
+			menuSystem->ticksSinceModeChange=SDL_GetTicks()-5000;//  현재의틱 하고 애가 들어갈떄의 틱하고 비교해서
+		else if(menuSystem->playMode==Online)						//시간이 얼마나 지났는가 확인하는건데 이게 5000미만일 떄 엔터를 눌르면 올려주는거임
 			menuSystem->action = GoToJoin;// #19 Kim : 1. 여기서 저게 온라인게임으로 되미녀 엑션 바뀌
 		else if (menuSystem -> playMode == Multi)
 			menuSystem->action = GoToMulti;
@@ -91,6 +93,8 @@ static void draw_vanity_screen(MenuSystem *menuSystem)
 	if(dt>3000)draw_playMode(menuSystem->playMode);
 	if (dt > 4000) draw_vanity_corporate_info();
 	if (dt > 5000) draw_vanity_animation(dt - 5000);
+
+
 }
 
 int getKey(void)// #19 Kim : 1. 여기서 키값 받아서 와따가따리
@@ -180,6 +184,12 @@ int online_mode_render(MenuSystem *menuSystem)// #19 Kim : 2. 여기서 그려�
 			menuSystem->action=WaitClient;
 			return 0;
 		}
+		else if(get==SDLK_BACKSPACE)//#35 makeRoom 에서 백스페이스 누를시에는 메인메뉴로감
+		{
+			menuSystem->action = Nothing;
+			return ReturnMenu;
+		}
+
 	}
 	else if(s_c_num==1)
 	{//Join room 부분일 때임
@@ -195,7 +205,6 @@ int online_mode_render(MenuSystem *menuSystem)// #19 Kim : 2. 여기서 그려�
 			return 0;
 		}
 	}
-
 	draw_online_mode(&s_c_num,tmp);
 	return 1;
 }

--- a/pacman/src/menu.c
+++ b/pacman/src/menu.c
@@ -16,7 +16,7 @@
 
 //time between each ghost-row appearance
 #define GHOST_BETWEEN 500
-static char tmp[100]={"000.000"};
+static char tmp[100]={"0.0.0.0"};
 static int index_num=0;
 static int s_c_num = 0;
 
@@ -110,6 +110,8 @@ int getKey(void)// #19 Kim : 1. 여기서 키값 받아서 와따가따리
 		return SDLK_KP_ENTER;// #19 Kim : 2. 엔터가 아니라 SDLK_RETURN 인듯. 엔터치면 ㅇㅅㅇ
 	else if(key_released(SDLK_PERIOD))
 		return SDLK_PERIOD;
+	else if(key_released(SDLK_BACKSPACE))//#25 ip 칠때 지워지도록.
+		return SDLK_BACKSPACE;
 	return 0;
 }
 
@@ -130,11 +132,11 @@ int multi_mode_render(MenuSystem *menuSystem)// # 9 Dong : 확장맵 테스트�
 
 	if(get==SDLK_UP&&s_c_num==1)
 	{
-			s_c_num = 0;
+		s_c_num = 0;
 	}
 	else if(get==SDLK_DOWN&&s_c_num==0)
 	{
-			s_c_num = 1;
+		s_c_num = 1;
 	}
 	else if(get == SDLK_KP_ENTER)
 	{
@@ -168,31 +170,32 @@ int online_mode_render(MenuSystem *menuSystem)// #19 Kim : 2. 여기서 그려�
 		menuSystem->playMode = Online_Client;//#25 클라이언트쪽 접속하는 코드 추
 		return JoinServer;
 	}
-	if(get==SDLK_UP&&s_c_num==1)
-	{
-		s_c_num--;
-	}
-	else if(get==SDLK_DOWN&&s_c_num==0)
-	{
-		s_c_num++;
-	}
-	else if(s_c_num==1 && ( (get>=48&&get<=57) ||get==SDLK_PERIOD)) //#25 닷 찍으면 문자열 들어가도록.
-		tmp[index_num++] = (char)get;
-	else if(get==SDLK_KP_ENTER)
-	{
-		if(s_c_num==0)//ROOM 만들 때
+	// 정리 Kim : 코드정리함
+	if(s_c_num==0)
+	{//make room 부분일 때
+		if(get==SDLK_DOWN)s_c_num++;
+		else if(get==SDLK_KP_ENTER)
 		{
-			draw_input_string("WAITING CLIENT");// #19 Kim : 2. waiting client 그려줌 이름을 맞게 바꿔줌
+			draw_input_string("WAITING CLIENT",4,15);// #19 Kim : 2. waiting client 그려줌 이름을 맞게 바꿔줌
 			menuSystem->action=WaitClient;
 			return 0;
 		}
-		else if(s_c_num==1)
+	}
+	else if(s_c_num==1)
+	{//Join room 부분일 때임
+		if(get==SDLK_UP)	s_c_num--;
+		else if((get>=48&&get<=57) ||get==SDLK_PERIOD) //#25 닷 찍으면 문자열 들어가도록.
+			tmp[index_num++] = (char)get;
+		else if(get == SDLK_BACKSPACE)//# 35 백스페이스 적용 되게 했음
+		{if(index_num!=0)tmp[--index_num]='\0';}
+		else if(get==SDLK_KP_ENTER)
 		{
-			draw_input_string("CONNECT SERVER");
+			draw_input_string("CONNECT SERVER",4,15);
 			menuSystem->action = JoinServer;
 			return 0;
 		}
 	}
+
 	draw_online_mode(&s_c_num,tmp);
 	return 1;
 }

--- a/pacman/src/menu.h
+++ b/pacman/src/menu.h
@@ -10,7 +10,8 @@ typedef enum
 	GoToJoin,// #19 Kim : 1. 메뉴에서 눌렀을때 열로가려고 ..만들었음일단..
 	GoToMulti, // # 9 Dong : 확장맵 테스트
 	WaitClient,// #19 Kim : 2. 방만들기 했을 때 클라이언트 기다리기
-	JoinServer // #25 join room 선택시 이액션
+	JoinServer, // #25 join room 선택시 이액션
+	ReturnMenu // #35 make 룸에서 백스페이스 키시 이액션
 } MenuAction;
 
 //Defines the menu system.

--- a/pacman/src/renderer.c
+++ b/pacman/src/renderer.c
@@ -13,7 +13,7 @@
 
 //
 void draw_online_mode(int *s_c_num ,char* tmp);//#19 Kim : 2.menu.c 에있는거 열로 옮겼음
-void draw_input_string(const char tmp[]);//#19 Kim : 2. 클라이언트 기다리는거 화면 추가. 이름을 맞게 바꿔줌
+void draw_input_string(const char tmp[],int x,int y);//#19 Kim : 2. 클라이언트 기다리는거 화면 추가. 이름을 맞게 바꿔줌
 
 //draws an image at a board coordinate
 void draw_image_coord(SDL_Surface *surface, int x, int y);
@@ -692,10 +692,11 @@ void draw_online_mode(int *s_c_num ,char* tmp)//#19 Kim : 1. 일단 메뉴에서
 		break;
 	}
 }
-void draw_input_string(const char tmp[])
+void draw_input_string(const char tmp[],int x,int y)
 {// #20 Kim : 1. 편하게 쓰기위해서 매개변수로 메세지 맘대로 할수있게
+	// #35 Kim 이거 한 이유는 그냥 앞에 set color 랑 텍스트 써주는거 매번 두개쓰기싫어섬임.
 	set_text_color(WhiteText);
-	draw_text_coord(get_screen(), tmp, 4, 15);
+	draw_text_coord(get_screen(), tmp, x, y);
 
 
 }

--- a/pacman/src/renderer.c
+++ b/pacman/src/renderer.c
@@ -14,7 +14,7 @@
 //
 void draw_online_mode(int *s_c_num ,char* tmp);//#19 Kim : 2.menu.c 에있는거 열로 옮겼음
 void draw_input_string(const char tmp[],int x,int y);//#19 Kim : 2. 클라이언트 기다리는거 화면 추가. 이름을 맞게 바꿔줌
-
+void draw_multi_mode(int *s_c_num);
 //draws an image at a board coordinate
 void draw_image_coord(SDL_Surface *surface, int x, int y);
 void draw_image_coord_offset(SDL_Surface *surface, int x, int y, int xOffset, int yOffset);

--- a/pacman/src/renderer.h
+++ b/pacman/src/renderer.h
@@ -116,5 +116,5 @@ void draw_mutil_mode(int *s_c_num); // # 9 Dong : 확장 맵 구현을 위한 �
 void draw_playMode(PlayMode playMode);//#13 kim : 메뉴에다가 그플레이ㄷ모드 그려죽ㅣ
 
 void draw_online_mode(int *s_c_num ,char* tmp);//#19 Kim : 2. menu.c에있는거 옮겼음
-void draw_input_string(const char tmp[]);//#19 Kim : 2. 클라이언트 기다리는거 화면 추가.
+void draw_input_string(const char tmp[],int x,int y);//#19 Kim : 2. 클라이언트 기다리는거 화면 추가.
 

--- a/pacman/src/renderer.h
+++ b/pacman/src/renderer.h
@@ -117,4 +117,4 @@ void draw_playMode(PlayMode playMode);//#13 kim : 메뉴에다가 그플레이�
 
 void draw_online_mode(int *s_c_num ,char* tmp);//#19 Kim : 2. menu.c에있는거 옮겼음
 void draw_input_string(const char tmp[],int x,int y);//#19 Kim : 2. 클라이언트 기다리는거 화면 추가.
-
+void draw_multi_mode(int *s_c_num);


### PR DESCRIPTION

정리 ,버그 #35 : menu.c쪽 함수 코드정리 , 지워지는거 구현이랑 pellet 구석꺼 안먹어지는거 버그픽스

먼저 pellet 멀티일때 안먹어지는건 간단하게 조건문에서 범위 늘려준거고

지워지는거 구현또한 백스페이스 키받고 그키면 문자열 인덱스 감산해주고

있던부분에 '\0' 넣어주도록 만들었음

코드정리는 online_mode_render 쪽에서 조건문 정리했음

버그 #35 : 메인에서 엔터 시 바로출력 , make room에서 백스페이스시 메인

menu_tick 함수 부분에서 SDL_getTicks - ticksSinceModeChange 를 통해서

다 출력되었는지 확인을 하고 만약 다출력이 안된 시간에 엔터가 받아졌다면

ticksSinceModeChange 의 값을 바꿔줘서 시간이 다 흐른척 함

make room 에서 백스페이스 시 메인은 ReturnMenu 라는 MenuAction enum 에서 하나더 추가

이거 리턴하면 state menu로 돌아가도록함
